### PR TITLE
Rc 0.1.7

### DIFF
--- a/.github/workflows/checkpr.yml
+++ b/.github/workflows/checkpr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "0.1.6"
+    "moduleversion": "0.1.7"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -80,6 +80,19 @@
             "problemMatcher": []
         },
         {
+            "label": "Sort Imports",
+            "type": "process",
+            "command": "${config:python.defaultInterpreterPath}",
+            "args": [
+                "-m",
+                "isort",
+                "src",
+                "--jobs",
+                "-1"
+            ],
+            "problemMatcher": []
+        },
+        {
             "label": "Format",
             "type": "process",
             "command": "${config:python.defaultInterpreterPath}",
@@ -212,6 +225,7 @@
                 "Install Test Dependencies",
                 "Install Dependencies",
                 "Security",
+                "Sort Imports",
                 "Format",
                 "Pylint",
                 "Test",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ If you're adding or amending SPARTN payload definitions or configuration databas
 ## Coding conventions
 
 * This is open source software. Code should be as simple and transparent as possible. Favour clarity over brevity.
-* The code should be compatible with Python 3.7+.
+* The code should be compatible with Python 3.8+.
 * The core code should be as generic and reusable as possible. We endeavour to limit the amount of processing dedicated to specific SPARTN message types, though this is sometimes unavoidable.
 * Avoid external library dependencies unless there's a compelling reason not to.
 * Code should be documented in accordance with [Sphinx](https://www.sphinx-doc.org/en/master/) docstring conventions.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Contributions welcome - please refer to [CONTRIBUTING.MD](https://github.com/sem
 ---
 ## <a name="installation">Installation</a>
 
-`pyspartn` is compatible with Python >=3.7 and has no third-party library dependencies.
+`pyspartn` is compatible with Python >=3.8 and has no third-party library dependencies.
 
 In the following, `python` & `pip` refer to the Python 3 executables. You may need to type 
 `python3` or `pip3`, depending on your particular environment.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 # pyspartn Release Notes
 
-### RELEASE CANDIDATE 0.1.6-alpha
+### RELEASE CANDIDATE 0.1.7-alpha
+
+CHANGES:
+
+1. Remove Python 3.7 from workflows and documentation.
+
+### RELEASE 0.1.6-alpha
 
 CHANGES:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ maintainers = [
   {name = "semuadmin", email = "semuadmin@semuconsulting.com"}
 ]
 description = "SPARTN protocol parser"
-version = "0.1.6"
+version = "0.1.7"
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Operating System :: OS Independent",
     "Development Status :: 2 - Pre-Alpha",
@@ -26,7 +26,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: End Users/Desktop",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -65,8 +64,7 @@ test = [
 ]
 
 [tool.black]
-line-length = 88
-target-version = ['py37']
+target-version = ['py38']
 
 [tool.bandit]
 exclude_dirs = ["docs", "examples", "tests"]
@@ -76,7 +74,7 @@ skips = []
 jobs = 0
 reports = "y"
 recursive = "y"
-py-version = "3.7"
+py-version = "3.8"
 fail-under = "9.6"
 fail-on = "E,F"
 clear-cache-post-run = "y"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ test = [
 [tool.black]
 target-version = ['py38']
 
+[tool.isort]
+py_version = 38
+profile = "black"
+
 [tool.bandit]
 exclude_dirs = ["docs", "examples", "tests"]
 skips = []

--- a/src/pyspartn/__init__.py
+++ b/src/pyspartn/__init__.py
@@ -7,18 +7,17 @@ Created on 10 Feb 2023
 """
 
 from pyspartn._version import __version__
-
 from pyspartn.exceptions import (
+    ParameterError,
     SPARTNMessageError,
     SPARTNParseError,
-    SPARTNTypeError,
     SPARTNStreamError,
-    ParameterError,
+    SPARTNTypeError,
 )
+from pyspartn.socket_stream import SocketStream
+from pyspartn.spartnhelpers import *
 from pyspartn.spartnmessage import SPARTNMessage
 from pyspartn.spartnreader import SPARTNReader
-from pyspartn.socket_stream import SocketStream
 from pyspartn.spartntypes_core import *
-from pyspartn.spartnhelpers import *
 
 version = __version__  # pylint: disable=invalid-name

--- a/src/pyspartn/_version.py
+++ b/src/pyspartn/_version.py
@@ -8,4 +8,4 @@ Created on 10 Feb 2023
 :license: BSD 3-Clause
 """
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/src/pyspartn/spartnhelpers.py
+++ b/src/pyspartn/spartnhelpers.py
@@ -11,9 +11,11 @@ Created on 10 Feb 2023
 # pylint: disable=invalid-name
 
 from datetime import datetime
+
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from pyspartn.spartntypes_core import TIMEBASE, SPARTN_DATA_FIELDS
+
 from pyspartn.exceptions import SPARTNMessageError
+from pyspartn.spartntypes_core import SPARTN_DATA_FIELDS, TIMEBASE
 
 
 def att2idx(att: str) -> int:

--- a/src/pyspartn/spartnmessage.py
+++ b/src/pyspartn/spartnmessage.py
@@ -15,30 +15,31 @@ Created on 10 Feb 2023
 # pylint: disable=invalid-name too-many-instance-attributes
 
 from os import getenv
+
 from pyspartn.exceptions import (
+    ParameterError,
     SPARTNMessageError,
     SPARTNParseError,
     SPARTNTypeError,
-    ParameterError,
 )
 from pyspartn.spartnhelpers import (
     bitsval,
+    convert_timetag,
+    decrypt,
+    escapeall,
     numbitsset,
     valid_crc,
-    escapeall,
-    decrypt,
-    convert_timetag,
 )
 from pyspartn.spartntypes_core import (
-    SPARTN_PRE,
-    SPARTN_MSGIDS,
-    SPARTN_DATA_FIELDS,
-    VALCRC,
-    NB,
-    STBMLEN,
-    PBBMLEN,
     CBBMLEN,
+    NB,
     NESTED_DEPTH,
+    PBBMLEN,
+    SPARTN_DATA_FIELDS,
+    SPARTN_MSGIDS,
+    SPARTN_PRE,
+    STBMLEN,
+    VALCRC,
 )
 from pyspartn.spartntypes_get import SPARTN_PAYLOADS_GET
 

--- a/src/pyspartn/spartnreader.py
+++ b/src/pyspartn/spartnreader.py
@@ -27,21 +27,17 @@ Created on 10 Feb 2023
 
 from os import getenv
 from socket import socket
+
+from pyspartn.exceptions import (
+    ParameterError,
+    SPARTNMessageError,
+    SPARTNParseError,
+    SPARTNTypeError,
+)
 from pyspartn.socket_stream import SocketStream
 from pyspartn.spartnhelpers import bitsval, valid_crc
-from pyspartn.exceptions import (
-    SPARTNParseError,
-    SPARTNMessageError,
-    SPARTNTypeError,
-    ParameterError,
-)
-from pyspartn.spartntypes_core import (
-    SPARTN_PREB,
-    VALCRC,
-    ERRRAISE,
-    ERRLOG,
-)
 from pyspartn.spartnmessage import SPARTNMessage
+from pyspartn.spartntypes_core import ERRLOG, ERRRAISE, SPARTN_PREB, VALCRC
 
 
 class SPARTNReader:

--- a/src/pyspartn/spartntypes_get.py
+++ b/src/pyspartn/spartntypes_get.py
@@ -10,12 +10,7 @@ Information Sourced from https://www.spartnformat.org/download/
 """
 # pylint: disable=too-many-lines, line-too-long
 
-from pyspartn.spartntypes_core import (
-    NB,
-    STBMLEN,
-    PBBMLEN,
-    CBBMLEN,
-)
+from pyspartn.spartntypes_core import CBBMLEN, NB, PBBMLEN, STBMLEN
 
 OCB_HDR = {  # OCB Header
     "SF005": "Solution issue of update (SIOU)",


### PR DESCRIPTION
# pyspartn Pull Request Template

## Description

Python 3.7 is officially end of life on 27 June 2023. This change removes Python 3.7 from workflows and documentation.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pynmeagps/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my SPARTN documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` pytest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
