### PR TITLE
Rc 0.1.9

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "0.1.8"
+    "moduleversion": "0.1.9"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -228,7 +228,7 @@
                 "Sort Imports",
                 "Format",
                 "Pylint",
-                //"Test",
+                "Test",
                 "Build",
                 "Sphinx HTML"
             ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -228,7 +228,7 @@
                 "Sort Imports",
                 "Format",
                 "Pylint",
-                "Test",
+                //"Test",
                 "Build",
                 "Sphinx HTML"
             ],

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 CHANGES:
 
 1. Add temporary override of decode flag for message types that cannot yet be properly decoded (e.g. OCB)
+1. Add `gad_plot.py` example to illustrate how to extract geographic area definitions from SPARTN-1X-GAD messages.
 
 ### RELEASE 0.1.8-alpha
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ### RELEASE 0.1.9-alpha
 
+ENHANCEMENTS:
+
+1. Add `enc2float` helper method to convert SPARTN encoded floating point values to floats.
+
 CHANGES:
 
 1. Add temporary override of decode flag for message types that cannot yet be properly decoded (e.g. OCB)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pyspartn Release Notes
 
+### RELEASE 0.1.9-alpha
+
+CHANGES:
+
+1. Add temporary override of decode flag for message types that cannot yet be properly decoded (e.g. OCB)
+
 ### RELEASE 0.1.8-alpha
 
 FIXES:

--- a/examples/gad_plot.py
+++ b/examples/gad_plot.py
@@ -1,0 +1,76 @@
+"""
+gad_plot.py
+
+Extracts geographic area definition coordinates from
+SPARTN-1X-GAD messages and saves them to a CSV file in
+WKT POLYGON format. You can import this format into a GIS desktop
+tool like QGIS using the Add Layer...Delimted Text Layer function.
+
+You'll need the SPARTN decryption key and the basedate (datetime
+the SPARTN data was originally captured) to decode the messages.
+
+Output should look something like this:
+
+areaid,area
+"0","POLYGON ((12.500 71.500, 12.500 74.900, 31.700 74.900, 31.700 71.500, 12.500 71.500))"
+"1","POLYGON ((10.200 68.200, 10.200 71.600, 21.700 71.600, 21.700 68.200, 10.200 68.200))"
+"2","POLYGON ((21.700 68.300, 21.700 71.800, 30.200 71.800, 30.200 68.300, 21.700 68.300))"
+etc.
+
+Created on 20 May 2023
+
+:author: semuadmin
+:copyright: SEMU Consulting © 2023
+:license: BSD 3-Clause
+"""
+# pylint: disable=invalid-name
+
+from datetime import datetime
+from pyspartn import SPARTNReader, enc2float
+
+INFILE = "spartn_ip.log"
+OUTFILE = "spartnGAD.csv"
+KEY = "6b30302427df05b4d98911ebff3a4d95"
+BASEDATE = datetime(2023, 6, 27, 22, 3, 0)
+
+
+def groupatt(msg, att, n):
+    """
+    Get value of attribute within group
+    """
+    return getattr(msg, f"{att}_{n+1:02}")
+
+
+with open(OUTFILE, "w", encoding="utf-8") as outfile:
+    with open(INFILE, "rb") as infile:
+        spr = SPARTNReader(
+            infile,
+            decode=True,
+            key=KEY,
+            basedate=BASEDATE,
+            quitonerror=2,
+        )
+        total = 0
+        outfile.write("areaid,area\n")
+        for raw, parsed in spr:
+            if parsed.identity == "SPARTN-1X-GAD":
+                areacount = parsed.SF030
+                for i, area in enumerate(range(areacount)):
+                    areaid = groupatt(parsed, "SF031", i)
+                    lat1 = enc2float(groupatt(parsed, "SF032", i), 0.1, -90)
+                    lon1 = enc2float(groupatt(parsed, "SF033", i), 0.1, -180)
+                    latnodes = groupatt(parsed, "SF034", i)
+                    lonnodes = groupatt(parsed, "SF035", i)
+                    latspacing = enc2float(groupatt(parsed, "SF036", i), 0.1, 0.1)
+                    lonspacing = enc2float(groupatt(parsed, "SF037", i), 0.1, 0.1)
+                    lat2 = lat1 + (latnodes * latspacing)
+                    lon2 = lon1 + (lonnodes * lonspacing)
+                    areaplot = (
+                        f'"{areaid}","POLYGON (({lon1:.3f} {lat1:.3f}, {lon1:.3f} {lat2:.3f},'
+                        + f'{lon2:.3f} {lat2:.3f}, {lon2:.3f} {lat1:.3f}, {lon1:.3f} {lat1:.3f}))"\n'
+                    )
+                    print(f"{areaid}: {lon1:.3f}, {lat1:.3f} - {lon2:.3f}, {lat2:.3f}")
+                    outfile.write(areaplot)
+                total += i
+
+print(f"{total} GAD area definitions captured in {OUTFILE}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
   {name = "semuadmin", email = "semuadmin@semuconsulting.com"}
 ]
 description = "SPARTN protocol parser"
-version = "0.1.8"
+version = "0.1.9"
 license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pyspartn/_version.py
+++ b/src/pyspartn/_version.py
@@ -8,4 +8,4 @@ Created on 10 Feb 2023
 :license: BSD 3-Clause
 """
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/src/pyspartn/spartnhelpers.py
+++ b/src/pyspartn/spartnhelpers.py
@@ -255,7 +255,7 @@ def datadesc(datafield: str) -> str:
     return desc
 
 
-def enc2float(value: int, res: float, rngmin: int) -> float:
+def enc2float(value: int, res: float, rngmin: float) -> float:
     """
     Convert encoded floating point value to float.
 

--- a/src/pyspartn/spartnhelpers.py
+++ b/src/pyspartn/spartnhelpers.py
@@ -253,3 +253,20 @@ def datadesc(datafield: str) -> str:
 
     (_, _, desc) = SPARTN_DATA_FIELDS[datafield[0:5]]
     return desc
+
+
+def enc2float(value: int, res: float, rngmin: int) -> float:
+    """
+    Convert encoded floating point value to float.
+
+    SPARTN protocol stores floating point numbers in
+    encoded integer format.
+
+    :param int value: encoded value
+    :param float res: resolution
+    :param float rngmin: minimum range value
+    :return: floating point value
+    :rtype: float
+    """
+
+    return (value * res) + rngmin

--- a/src/pyspartn/spartnmessage.py
+++ b/src/pyspartn/spartnmessage.py
@@ -157,10 +157,11 @@ class SPARTNMessage:
         offset = 0  # payload offset in bits
         index = []  # array of (nested) group indices
 
-        # TODO override decode flag for message types that cannot yet be decoded
-        self._decode = True
+        # ***********************************************************************************
+        # TODO temporary override of decode flag for message types that cannot yet be decoded
         if self.msgType in (0, 3, 4, 120) and self._decode is True:
             self._decode = False
+        # ***********************************************************************************
 
         # decrypt payload if encrypted
         if self.eaf and self._decode:

--- a/src/pyspartn/spartnmessage.py
+++ b/src/pyspartn/spartnmessage.py
@@ -76,7 +76,7 @@ class SPARTNMessage:
             raise SPARTNParseError(f"Unknown message preamble {self._preamble}")
 
         self._scaling = kwargs.get("scaling", False)
-        self._decode = kwargs.get("decode", True)
+        self._decode = kwargs.get("decode", False)
         key = kwargs.get("key", getenv("MQTTKEY", None))  # 128-bit key
         self._basedate = kwargs.get(
             "basedate", datetime.now()

--- a/src/pyspartn/spartnmessage.py
+++ b/src/pyspartn/spartnmessage.py
@@ -76,7 +76,7 @@ class SPARTNMessage:
             raise SPARTNParseError(f"Unknown message preamble {self._preamble}")
 
         self._scaling = kwargs.get("scaling", False)
-        self._decode = kwargs.get("decode", False)
+        self._decode = kwargs.get("decode", True)
         key = kwargs.get("key", getenv("MQTTKEY", None))  # 128-bit key
         self._basedate = kwargs.get(
             "basedate", datetime.now()

--- a/src/pyspartn/spartnmessage.py
+++ b/src/pyspartn/spartnmessage.py
@@ -157,6 +157,11 @@ class SPARTNMessage:
         offset = 0  # payload offset in bits
         index = []  # array of (nested) group indices
 
+        # TODO override decode flag for message types that cannot yet be decoded
+        self._decode = True
+        if self.msgType in (0, 3, 4, 120) and self._decode is True:
+            self._decode = False
+
         # decrypt payload if encrypted
         if self.eaf and self._decode:
             iv = self._get_iv()

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -10,7 +10,7 @@ Created on 10 Feb 2023
 
 import os
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from pyspartn.spartnhelpers import (
     att2name,
@@ -23,6 +23,7 @@ from pyspartn.spartnhelpers import (
     convert_timetag,
     numbitsset,
     datadesc,
+    enc2float,
 )
 from pyspartn.spartntypes_core import TIMEBASE
 from pyspartn.exceptions import SPARTNMessageError
@@ -171,6 +172,12 @@ class StaticTest(unittest.TestCase):
         self.assertEqual(res, "Ionosphere equation type")
         res = datadesc("SF043_01")
         self.assertEqual(res, "Area average vertical hydrostatic delay")
+
+    def testenc2float(self):  # test enc2float
+        res = enc2float(1332, 0.1, -90)
+        self.assertAlmostEqual(res, 43.20000000000002, 6)
+        res = enc2float(2033, 0.1, -180)
+        self.assertAlmostEqual(res, 23.30000000000001, 6)
 
 
 if __name__ == "__main__":

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -55,7 +55,7 @@ class StreamTest(unittest.TestCase):
         return self._strout.getvalue().strip()
 
     def testSerialize(self):  # test serialize()
-        msg1 = SPARTNReader.parse(self.spartntransport)
+        msg1 = SPARTNReader.parse(self.spartntransport, decode=False)
         msg2 = SPARTNMessage(transport=self.spartntransport)
         res = msg1.serialize()
         self.assertEqual(res, self.spartntransport)
@@ -72,7 +72,7 @@ class StreamTest(unittest.TestCase):
 
     def testrepr(self):  # test repr, check eval recreates original object
         EXPECTED_RESULT = "SPARTNMessage(transport=b's\\x00\\x12\\xe2\\x00|\\x10[\\x12H\\xf5\\t\\xa0\\xb4+\\x99\\x02\\x15\\xe2\\x05\\x85\\xb7\\x83\\xc5\\xfd\\x0f\\xfe\\xdf\\x18\\xbe\\x7fv \\xc3`\\x82\\x98\\x10\\x07\\xdc\\xeb\\x82\\x7f\\xcf\\xf8\\x9e\\xa3ta\\xad')"
-        msg1 = SPARTNReader.parse(self.spartntransport)
+        msg1 = SPARTNReader.parse(self.spartntransport, decode=False)
         self.assertEqual(repr(msg1), EXPECTED_RESULT)
         msg2 = eval(repr(msg1))
         self.assertEqual(str(msg1), str(msg2))


### PR DESCRIPTION
# pyspartn Pull Request Template

RELEASE CANDIDATE 0.1.9-alpha

ENHANCEMENTS:

1. Add `enc2float` helper method to convert SPARTN encoded floating point values to floats.

CHANGES:

1. Add temporary override of decode flag for message types that cannot yet be properly decoded (e.g. OCB). 
1. Add `gad_plot.py` example to illustrate how to extract geographic area definitions from SPARTN-1X-GAD messages.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] test enc2float method

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyspartn/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [`CONTRIBUTING.MD`](https://github.com/semuconsulting/pyspartn/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my SPARTN documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` pytest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
