### PR TITLE
Release Candidate 0.2.1-alpha

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "0.2.0"
+    "moduleversion": "0.2.1"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,32 +7,6 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Install Deploy Dependencies",
-            "type": "process",
-            "command": "${config:python.defaultInterpreterPath}",
-            "args": [
-                "-m",
-                "pip",
-                "install",
-                "--upgrade",
-                ".[deploy]"
-            ],
-            "problemMatcher": []
-        },
-        {
-            "label": "Install Test Dependencies",
-            "type": "process",
-            "command": "${config:python.defaultInterpreterPath}",
-            "args": [
-                "-m",
-                "pip",
-                "install",
-                "--upgrade",
-                ".[test]"
-            ],
-            "problemMatcher": []
-        },
-        {
             "label": "Install Dependencies",
             "type": "process",
             "command": "${config:python.defaultInterpreterPath}",
@@ -221,9 +195,6 @@
             "dependsOrder": "sequence",
             "dependsOn": [
                 "Clean",
-                "Install Deploy Dependencies",
-                "Install Test Dependencies",
-                "Install Dependencies",
                 "Security",
                 "Sort Imports",
                 "Format",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pyspartn Release Notes
 
+### RELEASE 0.2.1-alpha
+
+FIXES:
+
+1. Fix "no authInd attribute" error when parsing PointPerfect NTRIP SPARTN datastreams.
+
 ### RELEASE 0.2.0-alpha
 
 FIXES:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyspartn"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "SPARTN protocol parser"
-version = "0.2.0"
+version = "0.2.1"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pyspartn/_version.py
+++ b/src/pyspartn/_version.py
@@ -8,4 +8,4 @@ Created on 10 Feb 2023
 :license: BSD 3-Clause
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/pyspartn/spartnmessage.py
+++ b/src/pyspartn/spartnmessage.py
@@ -377,7 +377,7 @@ class SPARTNMessage:
         try:  # TODO temporary DEBUG of payload failure
             val = bitsval(self._payload, offset, attlen)
         except SPARTNMessageError as err:
-            print(self)
+            # print(self)
             raise (err)
 
         setattr(self, keyr, val)

--- a/src/pyspartn/spartnmessage.py
+++ b/src/pyspartn/spartnmessage.py
@@ -143,18 +143,19 @@ class SPARTNMessage:
         # start of embAuth
         pos += self.nData * 8
         aln = 0
-        if self.authInd > 1:
-            if self.embAuthLen == 0:
-                aln = 64
-            elif self.embAuthLen == 1:
-                aln = 94
-            elif self.embAuthLen == 2:
-                aln = 128
-            elif self.embAuthLen == 3:
-                aln = 256
-            elif self.embAuthLen == 4:
-                aln = 512
-            self.embAuth = bitsval(self._transport, pos, aln)
+        if hasattr(self, "authInd"):
+            if self.authInd > 1:
+                if self.embAuthLen == 0:
+                    aln = 64
+                elif self.embAuthLen == 1:
+                    aln = 94
+                elif self.embAuthLen == 2:
+                    aln = 128
+                elif self.embAuthLen == 3:
+                    aln = 256
+                elif self.embAuthLen == 4:
+                    aln = 512
+                self.embAuth = bitsval(self._transport, pos, aln)
 
         # start of CRC
         pos += aln


### PR DESCRIPTION
# pyspartn Pull Request Template

## Description

Fixes "no authInd" attribute error when parsing PointPerfect NTRIP SPARTN datastreams

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Tested with PointPerfect MQTT 100H service using NTRIP credentials

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyspartn/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [`CONTRIBUTING.MD`](https://github.com/semuconsulting/pyspartn/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my SPARTN documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` pytest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
