### PR TITLE
Fix different constellation timebase resolution by trying 12h prior, during, and after given basedate

### DIFF
--- a/src/pyspartn/spartnhelpers.py
+++ b/src/pyspartn/spartnhelpers.py
@@ -253,7 +253,7 @@ def convert_timetag(timetag16: int, basedate: datetime = datetime.now()) -> int:
 
     16-bit timetag represents seconds past 'base date' (the datetime the SPARTN
     message was originally sent, to the nearest half-day). It requires knowledge
-    of this base date to convert unambiguously to a 32-bit timetag equlvalent, e.g.
+    of this base date to convert unambiguously to a 32-bit timetag equivalent, e.g.
 
     If base date to nearest half day was "2023-06-27 12:00:00", a timetag16 of
     32580 represents a datetime of:
@@ -264,18 +264,30 @@ def convert_timetag(timetag16: int, basedate: datetime = datetime.now()) -> int:
 
     (2023-06-27 21:03:00 - 2010-01-01 00:00:00) = 425595780 seconds
 
+    All timetag16 are given in their respective constellation timezone :
+    UTC = GPS + 18s = GAL + 18s = QZSS + 18s = BEI + 4s = GLO - 10800s
+
+    Since all timetags are in GNSS constellation time and basedate is timezone-naive,
+    we calculate three possible 32-bit timetags : basedate, basedate plus half a day,
+    basedate minus half a day, so all constellations and basedate time reference are tried.
+    We then select the unambiguous resolution the closest in time to the original basedate.
+
     :param int timetag16: 16-bit gnssTimeTag
-    :param datetime basedate: original processing datetime to nearest half day
+    :param datetime basedate: original processing datetime accurate to 3 hours
     :return: 32-bit gnssTimeTag
     :rtype: int
     """
 
-    base16 = datetime(basedate.year, basedate.month, basedate.day, 0, 0, 0)
-    secs = timetag16
-    if basedate.hour >= 12:
-        secs += 43200
-    time16 = base16 + timedelta(seconds=secs)
-    return date2timetag(time16)
+    secs_half_day = 12 * 60 * 60
+    basedate_seconds = date2timetag(basedate)
+    floor_halfday_timetag = basedate_seconds - (basedate_seconds % secs_half_day) + timetag16
+
+    time_options = [floor_halfday_timetag - secs_half_day,
+                    floor_halfday_timetag,
+                    floor_halfday_timetag + secs_half_day]
+
+    closest_time_tag = min(time_options, key=lambda x: abs(x - basedate_seconds))
+    return closest_time_tag
 
 
 def enc2float(value: int, res: float, rngmin: float = 0) -> float:

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -130,10 +130,15 @@ class StaticTest(unittest.TestCase):
         self.assertEqual(msg, pt[0:-pad])
 
     def testtimetag(self):
-        basedate = datetime(2023, 6, 27, 23, 13, 0)
-        EXPECTED_RES = 425595780
-        res = convert_timetag(32580, basedate)
-        self.assertEqual(res, EXPECTED_RES)
+        basedate_gps = datetime(2023, 6, 27, 23, 13, 0)
+        EXPECTED_RES_GPS = 425595780
+        res = convert_timetag(32580, basedate_gps)
+        self.assertEqual(res, EXPECTED_RES_GPS)
+
+        basedate_glo = datetime(2024, 4, 25, 11, 37, 0)
+        EXPECTED_RES_GLO = 451751822
+        res = convert_timetag(9422, basedate_glo)
+        self.assertEqual(res, EXPECTED_RES_GLO)
 
     def testiv(self):
         IV32 = "031800c03cb4306c2b40000000000001"


### PR DESCRIPTION


# pyspartn Pull Request Template

## Description

Different constellations are using different time reference :
GPS = GAL = QZSS = UTC -18s
BEI = UTC -14
GLO = UTC + 3h (exactly 3h, 0 seconds)

Because of that, passing a basedate to convert a 16 bits timetag to 32 bits unambiguous can be either
- Correct
- Wrong because basedate is ahead of the constellation (GPS for example)
- Wrong because the basedate is behind the constellation (GLONASS for example)

In order to account for those time difference not being in sync, 3 unambitious solutions are calculated :
- At the time of basedate
- 12h after basedate
- 12h prior to basedate
The closest in time is the one returned

By doing so, basedate can be up to 3h inaccurate (as GLONASS is +3h ahead) and still allow for a correct parsing 

Fixes #17 

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 85% code coverage.

- [x] Timetag unambiguity test (testtimetag) extended to test GLONASS ambiguity at the critical time where it would prior fail

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyspartn/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [`CONTRIBUTING.MD`](https://github.com/semuconsulting/pyspartn/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my public domain SPARTN documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` pytest suite to maintain >= 85% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
