### PR TITLE
RC 1.0.4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
     "python3.8InterpreterPath": "/Library/Frameworks/Python.framework/Versions/3.8/bin/python3.8",
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.3"
+    "moduleversion": "1.0.4"
 }

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ class pyspartn.spartnreader.SPARTNReader(stream, **kwargs)
 
 You can create a `SPARTNReader` object by calling the constructor with an active stream object. 
 The stream object can be any data stream which supports a `read(n) -> bytes` method (e.g. File or Serial, with 
-or without a buffer wrapper). `pyspartn` implements an internal `SocketStream` class to allow sockets to be read in the same way as other streams.
+or without a buffer wrapper). `pyspartn` implements an internal `SocketWrapper` class to allow sockets to be read in the same way as other streams.
 
 Individual SPARTN messages can then be read using the `SPARTNReader.read()` function, which returns both the raw binary data (as bytes) and the parsed data (as a `SPARTNMessage`, via the `parse()` method). The function is thread-safe in so far as the incoming data stream object is thread-safe. `SPARTNReader` also implements an iterator. See examples below.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 ### RELEASE 1.0.3
 
+CHANGES:
+
+1. Drop active support for Python 3.8 - now EOL as at October 2024.
+
+### RELEASE 1.0.3
+
 FIXES:
 
 1. Add offsets to SF043, SF045 and SF048 - thanks to @jonathanmuller for contribution.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,9 @@
 
 CHANGES:
 
+1. Add active support for Python 3.13
 1. Drop active support for Python 3.8 - now EOL as at October 2024.
+1. Rename socket_stream to socket_wrapper for clarity.
 
 ### RELEASE 1.0.3
 

--- a/docs/pyspartn.rst
+++ b/docs/pyspartn.rst
@@ -12,10 +12,10 @@ pyspartn.exceptions module
    :undoc-members:
    :show-inheritance:
 
-pyspartn.socket\_stream module
-------------------------------
+pyspartn.socket\_wrapper module
+-------------------------------
 
-.. automodule:: pyspartn.socket_stream
+.. automodule:: pyspartn.socket_wrapper
    :members:
    :undoc-members:
    :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyspartn"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "SPARTN protocol parser"
-version = "1.0.3"
+version = "1.0.4"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/pyspartn/__init__.py
+++ b/src/pyspartn/__init__.py
@@ -14,7 +14,7 @@ from pyspartn.exceptions import (
     SPARTNStreamError,
     SPARTNTypeError,
 )
-from pyspartn.socket_stream import SocketStream
+from pyspartn.socket_wrapper import SocketWrapper
 from pyspartn.spartnhelpers import *
 from pyspartn.spartnmessage import SPARTNMessage
 from pyspartn.spartnreader import SPARTNReader

--- a/src/pyspartn/_version.py
+++ b/src/pyspartn/_version.py
@@ -8,4 +8,4 @@ Created on 10 Feb 2023
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"

--- a/src/pyspartn/socket_wrapper.py
+++ b/src/pyspartn/socket_wrapper.py
@@ -1,5 +1,5 @@
 """
-socket_stream class.
+socket_wrapper.py
 
 A skeleton socket wrapper which provides basic stream-like
 read(bytes) and readline() methods.
@@ -19,7 +19,7 @@ Created on 4 Apr 2022
 from socket import socket
 
 
-class SocketStream:
+class SocketWrapper:
     """
     socket stream class.
     """

--- a/src/pyspartn/spartnreader.py
+++ b/src/pyspartn/spartnreader.py
@@ -54,7 +54,7 @@ from pyspartn.exceptions import (
     SPARTNStreamError,
     SPARTNTypeError,
 )
-from pyspartn.socket_stream import SocketStream
+from pyspartn.socket_wrapper import SocketWrapper
 from pyspartn.spartnhelpers import bitsval, naive2aware, timetag2date, valid_crc
 from pyspartn.spartnmessage import SPARTNMessage
 from pyspartn.spartntables import ALN_ENUM
@@ -93,7 +93,7 @@ class SPARTNReader:
         # pylint: disable=too-many-arguments
 
         if isinstance(datastream, socket):
-            self._stream = SocketStream(datastream, bufsize=bufsize)
+            self._stream = SocketWrapper(datastream, bufsize=bufsize)
         else:
             self._stream = datastream
         self.key = getenv("MQTTKEY", None) if key is None else key

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -1,6 +1,6 @@
 """
 Socket reader tests for pyspartn - uses dummy socket class
-to achieve 99% test coverage of SocketStream.
+to achieve 99% test coverage of SocketWrapper.
 
 Created on 11 May 2022
 


### PR DESCRIPTION
# pyspartn Pull Request Template

## Description

1. Add active support for Python 3.13.0.
1. Drop active support for Python 3.8 - now EOL as at October 2024.
1. Rename socket_stream to socket_wrapper for clarity.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 90% code coverage.

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyspartn/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [`CONTRIBUTING.MD`](https://github.com/semuconsulting/pyspartn/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my public domain SPARTN documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` pytest suite to maintain >= 90% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
