### PR TITLE
Fix HPAC grid residual decoding: group suffix on SF051/SF063 conditionals, repeat residuals per grid point (SF039)

### DIFF
--- a/src/pyspartn/spartntypes_get.py
+++ b/src/pyspartn/spartntypes_get.py
@@ -180,12 +180,12 @@ TROP_DATA_BLOCK = {  # table 6.16 Troposphere Data Block
         {
             "SF051": "Troposphere residual field size",
             "optSF051-0": (
-                ("SF051", 0),  # if SF051 = 0
-                {"SF052": "Troposphere grid residuals"},
+                ("SF051+1", 0),  # if SF051 = 0
+                {"groupSF052": ("SF039+1", {"SF052": "Troposphere grid residuals"})},
             ),
             "optSF051-1": (  # if SF051 = 1
-                ("SF051", 1),  # if SF051 = 1
-                {"SF053": "Troposphere grid residuals"},
+                ("SF051+1", 1),  # if SF051 = 1
+                {"groupSF053": ("SF039+1", {"SF053": "Troposphere grid residuals"})},
             ),
         },
     ),
@@ -243,20 +243,20 @@ ION_SAT_BLOCK = {  # table 6.20 Ionosphere Satellite Block
         {
             "SF063": "Ionosphere residual field size",
             "optSF063-0": (
-                ("SF063", 0),  # if SF063 = 0
-                {"SF064": "Ionosphere grid residuals"},
+                ("SF063+2", 0),  # if SF063 = 0
+                {"groupSF064": ("SF039+1", {"SF064": "Ionosphere grid residuals"})},
             ),
             "optSF063-1": (
-                ("SF063", 1),  # if SF063 = 1
-                {"SF065": "Ionosphere grid residuals"},
+                ("SF063+2", 1),  # if SF063 = 1
+                {"groupSF065": ("SF039+1", {"SF065": "Ionosphere grid residuals"})},
             ),
             "optSF063-2": (
-                ("SF063", 2),  # if SF063 = 2
-                {"SF066": "Ionosphere grid residuals"},
+                ("SF063+2", 2),  # if SF063 = 2
+                {"groupSF066": ("SF039+1", {"SF066": "Ionosphere grid residuals"})},
             ),
             "optSF063-3": (
-                ("SF063", 3),  # if SF063 = 3
-                {"SF067": "Ionosphere grid residuals"},
+                ("SF063+2", 3),  # if SF063 = 3
+                {"groupSF067": ("SF039+1", {"SF067": "Ionosphere grid residuals"})},
             ),
         },
     ),


### PR DESCRIPTION

Fixes #43

Two defects in the shared HPAC building blocks (`AREA_DATA_BLOCK` and
`ION_SAT_BLOCK` in `spartntypes_get.py`):

1. The residual-size conditionals referenced the field name without the
   group-nesting suffix — `("SF051", 0)` instead of `("SF051+1", 0)`
   (one group level, inside `groupAtm`) and `("SF063", 0)` instead of
   `("SF063+2", 0)` (two levels, inside `groupAtm` → `groupSF011`).
   The neighbouring conditionals in the same blocks (`SF041+1`,
   `SF044+1`, `SF056+2`) already use the convention correctly.
2. The residual fields SF052/SF053 and SF064–SF067 were declared as
   single fields; per the SPARTN ICD they repeat once per grid point
   (SF039 + 1 times). They are now wrapped in repeating groups.

Because both blocks are spread (`**AREA_DATA_BLOCK` /
`**ION_SAT_BLOCK`) into all five HPAC definitions, this single fix
covers GPS, GLO, GAL, BEI and QZS.

**Verification** (file-level fix only, no runtime patching):
- 4/4 unencrypted demo frames decode, including the residual-grid frame
  (16 residual attributes present) — sample attached to the issue.
- A 4 167-frame real-world stream (SSRZ→SPARTN conversion of the German
  SAPOS service) parses cleanly.
- Full cross-validation against our independent C encoder: 152 field
  checks across both coefficient sizes, equation types 0–2 and all four
  residual resolutions — bit-exact round trip.
- Identity check confirms all five constellation definitions share the
  fixed block objects.

Note: the repeating-group keys are named `groupSF052`/`groupSF053`/
`groupSF064`–`groupSF067` here (matching the file's `groupSF011`
convention) rather than the `groupT52`/`groupI64` names used in the
issue snippet — cosmetic only.

